### PR TITLE
Release 60

### DIFF
--- a/include/clang/Driver/Options.td
+++ b/include/clang/Driver/Options.td
@@ -2913,6 +2913,8 @@ def no_fortran_main: Flag<["-"], "fno-fortran-main">, Group<gfortran_Group>,
   HelpText<"Don't link in Fortran main">;
 def Mnomain: Flag<["-"], "Mnomain">, Group<pgi_fortran_Group>,
   HelpText<"Don't link in Fortran main">;
+def frelaxed_math : Flag<["-"], "frelaxed-math">, Group<pgi_fortran_Group>,
+  HelpText<"Use relaxed Math intrinsic functions">;
 
 // Flang internal debug options
 def Mx_EQ : Joined<["-"], "Mx,">, Group<pgi_fortran_Group>;

--- a/lib/Driver/ToolChain.cpp
+++ b/lib/Driver/ToolChain.cpp
@@ -785,6 +785,7 @@ void ToolChain::AddFortranStdlibLibArgs(const ArgList &Args,
   }
   CmdArgs.push_back("-lflang");
   CmdArgs.push_back("-lflangrti");
+  CmdArgs.push_back("-lpgmath");
   if( useOpenMP ) {
     CmdArgs.push_back("-lomp");
   }

--- a/lib/Driver/ToolChains/Flang.cpp
+++ b/lib/Driver/ToolChains/Flang.cpp
@@ -767,6 +767,7 @@ void FlangFrontend::ConstructJob(Compilation &C, const JobAction &JA,
   LowerCmdArgs.push_back("-x"); LowerCmdArgs.push_back("70"); LowerCmdArgs.push_back("0x8000");
   LowerCmdArgs.push_back("-x"); LowerCmdArgs.push_back("122"); LowerCmdArgs.push_back("1");
   LowerCmdArgs.push_back("-x"); LowerCmdArgs.push_back("125"); LowerCmdArgs.push_back("0x20000");
+  LowerCmdArgs.push_back("-x"); LowerCmdArgs.push_back("164"); LowerCmdArgs.push_back("0x800000");
   LowerCmdArgs.push_back("-quad");
   LowerCmdArgs.push_back("-x"); LowerCmdArgs.push_back("59"); LowerCmdArgs.push_back("4");
   LowerCmdArgs.push_back("-tp"); LowerCmdArgs.push_back("px");


### PR DESCRIPTION
1. Enable new name generation for math intrinsic calls
2. Undo default IEEE setting.
3. Fix the command line option interpretation to choose the last one among the conflicting flags to be the final effect. The conflicting flags being
   i.   -ffast-math / -Ofast
   ii.  -fno-fast-math
   iii. -Kieee
   iv. -Knoieee
   v.  -frelaxed-math
4. Fix "-Ofast" to have the effects of "-ffast-math" along with "-O2"
5. Link libpgmath library