### PR TITLE
Fix bug in ieee flag generation

### DIFF
--- a/lib/Driver/ToolChains/Flang.cpp
+++ b/lib/Driver/ToolChains/Flang.cpp
@@ -537,6 +537,10 @@ void FlangFrontend::ConstructJob(Compilation &C, const JobAction &JA,
     // Lower: -ieee 0
     LowerCmdArgs.push_back("-ieee");
     LowerCmdArgs.push_back("0");
+  } else {
+    // Lower: -ieee 0
+    LowerCmdArgs.push_back("-ieee");
+    LowerCmdArgs.push_back("0");
   }
 
   /***** Upper part of the Fortran frontend *****/


### PR DESCRIPTION
If none of the following flags were used, the "-ieee 0" option would not have been generated before this fix.
-ffast-math
-frelaxed-math
-Kieee