### PR TITLE
Port to AArch64. Initial source code checkin from Cavium.

### DIFF
--- a/lib/CodeGen/CodeGenAction.cpp
+++ b/lib/CodeGen/CodeGenAction.cpp
@@ -1020,10 +1020,37 @@ void CodeGenAction::ExecuteAction() {
     Ctx.setInlineAsmDiagnosticHandler(BitcodeInlineAsmDiagHandler,
                                       &CI.getDiagnostics());
 
+    const CodeGenOptions &CodeGenOpts = CI.getCodeGenOpts();
+    DiagnosticsEngine &Diags = CI.getDiagnostics();
+    std::unique_ptr<llvm::ToolOutputFile> OptRecordFile;
+
+    if (!CodeGenOpts.OptRecordFile.empty()) {
+      std::error_code EC;
+      OptRecordFile =
+        llvm::make_unique<llvm::ToolOutputFile>(CodeGenOpts.OptRecordFile,
+                                                EC, sys::fs::F_None);
+
+      if (EC) {
+        Diags.Report(diag::err_cannot_open_file) <<
+          CodeGenOpts.OptRecordFile << EC.message();
+        return;
+      }
+
+      Ctx.setDiagnosticsOutputFile(
+        llvm::make_unique<yaml::Output>(OptRecordFile->os()));
+
+      if (CodeGenOpts.getProfileUse() != CodeGenOptions::ProfileNone)
+        Ctx.setDiagnosticsHotnessRequested(true);
+    }
+
     EmitBackendOutput(CI.getDiagnostics(), CI.getHeaderSearchOpts(),
                       CI.getCodeGenOpts(), TargetOpts, CI.getLangOpts(),
                       CI.getTarget().getDataLayout(), TheModule.get(), BA,
                       std::move(OS));
+
+    if (OptRecordFile)
+      OptRecordFile->keep();
+
     return;
   }
 


### PR DESCRIPTION
The code that writes the optimization analysis to a file (-fsave-optimization-record) was removed from the flang port. This changeset reinserts the code at the appropriate place.
