### PR TITLE
Enable vectorization of libpgmath intrinsic calls

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -388,6 +388,11 @@ endif()
 
 add_definitions( -D_GNU_SOURCE )
 
+option(FLANG_LLVM_EXTENSIONS "enable the Flang LLVM extensions" OFF)
+if(FLANG_LLVM_EXTENSIONS)
+  add_definitions( -DFLANG_LLVM_EXTENSIONS )
+endif()
+
 option(CLANG_BUILD_TOOLS
   "Build the Clang tools. If OFF, just generate build targets." ON)
 

--- a/include/clang/Driver/Options.td
+++ b/include/clang/Driver/Options.td
@@ -1246,7 +1246,7 @@ def fno_experimental_new_pass_manager : Flag<["-"], "fno-experimental-new-pass-m
   Group<f_clang_Group>, Flags<[CC1Option]>,
   HelpText<"Disables an experimental new pass manager in LLVM.">;
 def fveclib : Joined<["-"], "fveclib=">, Group<f_Group>, Flags<[CC1Option]>,
-    HelpText<"Use the given vector functions library">, Values<"Accelerate,SVML,none">;
+    HelpText<"Use the given vector functions library">, Values<"Accelerate,SVML,PGMATH,none">;
 def fno_lax_vector_conversions : Flag<["-"], "fno-lax-vector-conversions">, Group<f_Group>,
   HelpText<"Disallow implicit conversions between vectors with a different number of elements or different element types">, Flags<[CC1Option]>;
 def fno_merge_all_constants : Flag<["-"], "fno-merge-all-constants">, Group<f_Group>,

--- a/include/clang/Frontend/CodeGenOptions.h
+++ b/include/clang/Frontend/CodeGenOptions.h
@@ -52,7 +52,8 @@ public:
   enum VectorLibrary {
     NoLibrary,  // Don't use any vector library.
     Accelerate, // Use the Accelerate framework.
-    SVML        // Intel short vector math library.
+    SVML,       // Intel short vector math library.
+    PGMATH      // PGI math library.
   };
 
 

--- a/lib/CodeGen/BackendUtil.cpp
+++ b/lib/CodeGen/BackendUtil.cpp
@@ -314,6 +314,9 @@ static TargetLibraryInfoImpl *createTLII(llvm::Triple &TargetTriple,
   case CodeGenOptions::SVML:
     TLII->addVectorizableFunctionsFromVecLib(TargetLibraryInfoImpl::SVML);
     break;
+  case CodeGenOptions::PGMATH:
+    TLII->addVectorizableFunctionsFromVecLib(TargetLibraryInfoImpl::PGMATH);
+    break;
   default:
     break;
   }

--- a/lib/Driver/ToolChains/Clang.cpp
+++ b/lib/Driver/ToolChains/Clang.cpp
@@ -3286,7 +3286,14 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
   else
     CmdArgs.push_back(Args.MakeArgString(getToolChain().getThreadModel()));
 
+#ifdef FLANG_LLVM_EXTENSIONS
+  if(Args.getLastArg(options::OPT_fveclib))
+    Args.AddLastArg(CmdArgs, options::OPT_fveclib);
+  else 
+    CmdArgs.push_back("-fveclib=PGMATH");
+#else
   Args.AddLastArg(CmdArgs, options::OPT_fveclib);
+#endif
 
   if (Args.hasFlag(options::OPT_fmerge_all_constants,
                    options::OPT_fno_merge_all_constants, false))

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -486,6 +486,8 @@ static bool ParseCodeGenArgs(CodeGenOptions &Opts, ArgList &Args, InputKind IK,
       Opts.setVecLib(CodeGenOptions::Accelerate);
     else if (Name == "SVML")
       Opts.setVecLib(CodeGenOptions::SVML);
+    else if (Name == "PGMATH")
+      Opts.setVecLib(CodeGenOptions::PGMATH);
     else if (Name == "none")
       Opts.setVecLib(CodeGenOptions::NoLibrary);
     else


### PR DESCRIPTION
This PR adds PGMATH as one of the values for `-fveclib` flag. 
Also makes `-fveclib=PGMATH` the default option when 
a. User has not explicitly provided the `-fveclib` option.
b. The optimization level supports vectorization.