### PR TITLE
Move PGMATH vectorization changes under FLANG_LLVM_EXTENIONS ifdef

### DIFF
--- a/include/clang/Frontend/CodeGenOptions.h
+++ b/include/clang/Frontend/CodeGenOptions.h
@@ -52,8 +52,10 @@ public:
   enum VectorLibrary {
     NoLibrary,  // Don't use any vector library.
     Accelerate, // Use the Accelerate framework.
-    SVML,       // Intel short vector math library.
-    PGMATH      // PGI math library.
+#ifdef FLANG_LLVM_EXTENSIONS
+    PGMATH,     // PGI math library.
+#endif
+    SVML        // Intel short vector math library.
   };
 
 

--- a/lib/CodeGen/BackendUtil.cpp
+++ b/lib/CodeGen/BackendUtil.cpp
@@ -314,9 +314,11 @@ static TargetLibraryInfoImpl *createTLII(llvm::Triple &TargetTriple,
   case CodeGenOptions::SVML:
     TLII->addVectorizableFunctionsFromVecLib(TargetLibraryInfoImpl::SVML);
     break;
+#ifdef FLANG_LLVM_EXTENSIONS
   case CodeGenOptions::PGMATH:
     TLII->addVectorizableFunctionsFromVecLib(TargetLibraryInfoImpl::PGMATH);
     break;
+#endif
   default:
     break;
   }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -486,8 +486,10 @@ static bool ParseCodeGenArgs(CodeGenOptions &Opts, ArgList &Args, InputKind IK,
       Opts.setVecLib(CodeGenOptions::Accelerate);
     else if (Name == "SVML")
       Opts.setVecLib(CodeGenOptions::SVML);
+#ifdef FLANG_LLVM_EXTENSIONS
     else if (Name == "PGMATH")
       Opts.setVecLib(CodeGenOptions::PGMATH);
+#endif
     else if (Name == "none")
       Opts.setVecLib(CodeGenOptions::NoLibrary);
     else


### PR DESCRIPTION
With this change, flang can built with any LLVM. However in order to use vectorization capabilities of libpgmath, one needs to enable FLANG_LLVM_EXTENSIONS