### PR TITLE
Set flang default to use barriers for atomics.

### DIFF
--- a/lib/Driver/ToolChains/Flang.cpp
+++ b/lib/Driver/ToolChains/Flang.cpp
@@ -215,6 +215,13 @@ void FlangFrontend::ConstructJob(Compilation &C, const JobAction &JA,
       CommonCmdArgs.push_back("-x");
       CommonCmdArgs.push_back("69");
       CommonCmdArgs.push_back("0x400");
+
+      // Disable use of native atomic instructions
+      // for OpenMP atomics pending either a named
+      // option or a libatomic bundled with flang.
+      UpperCmdArgs.push_back("-x");
+      UpperCmdArgs.push_back("69");
+      UpperCmdArgs.push_back("0x1000");
     }
   }
 
@@ -331,46 +338,6 @@ void FlangFrontend::ConstructJob(Compilation &C, const JobAction &JA,
     UpperCmdArgs.push_back(fl);
     UpperCmdArgs.push_back("124");
     UpperCmdArgs.push_back("0x10");
-  }
-
-  // Set a -x flag for first part of Fortran frontend
-  for (Arg *A : Args.filtered(options::OPT_Hx_EQ)) {
-    A->claim();
-    StringRef Value = A->getValue();
-    auto XFlag = Value.split(",");
-    UpperCmdArgs.push_back("-x");
-    UpperCmdArgs.push_back(Args.MakeArgString(XFlag.first));
-    UpperCmdArgs.push_back(Args.MakeArgString(XFlag.second));
-  }
-
-  // Set a -y flag for first part of Fortran frontend
-  for (Arg *A : Args.filtered(options::OPT_Hy_EQ)) {
-    A->claim();
-    StringRef Value = A->getValue();
-    auto XFlag = Value.split(",");
-    UpperCmdArgs.push_back("-y");
-    UpperCmdArgs.push_back(Args.MakeArgString(XFlag.first));
-    UpperCmdArgs.push_back(Args.MakeArgString(XFlag.second));
-  }
-
-  // Set a -q (debug) flag for first part of Fortran frontend
-  for (Arg *A : Args.filtered(options::OPT_Hq_EQ)) {
-    A->claim();
-    StringRef Value = A->getValue();
-    auto XFlag = Value.split(",");
-    UpperCmdArgs.push_back("-q");
-    UpperCmdArgs.push_back(Args.MakeArgString(XFlag.first));
-    UpperCmdArgs.push_back(Args.MakeArgString(XFlag.second));
-  }
-
-  // Set a -qq (debug) flag for first part of Fortran frontend
-  for (Arg *A : Args.filtered(options::OPT_Hqq_EQ)) {
-    A->claim();
-    StringRef Value = A->getValue();
-    auto XFlag = Value.split(",");
-    UpperCmdArgs.push_back("-qq");
-    UpperCmdArgs.push_back(Args.MakeArgString(XFlag.first));
-    UpperCmdArgs.push_back(Args.MakeArgString(XFlag.second));
   }
 
   // Pass an arbitrary flag for first part of Fortran frontend
@@ -765,6 +732,46 @@ void FlangFrontend::ConstructJob(Compilation &C, const JobAction &JA,
     for (auto Arg : Args.filtered(options::OPT_Mchkptr)) {
       Arg->claim();
     }
+  }
+
+  // Set a -x flag for first part of Fortran frontend
+  for (Arg *A : Args.filtered(options::OPT_Hx_EQ)) {
+    A->claim();
+    StringRef Value = A->getValue();
+    auto XFlag = Value.split(",");
+    UpperCmdArgs.push_back("-x");
+    UpperCmdArgs.push_back(Args.MakeArgString(XFlag.first));
+    UpperCmdArgs.push_back(Args.MakeArgString(XFlag.second));
+  }
+
+  // Set a -y flag for first part of Fortran frontend
+  for (Arg *A : Args.filtered(options::OPT_Hy_EQ)) {
+    A->claim();
+    StringRef Value = A->getValue();
+    auto XFlag = Value.split(",");
+    UpperCmdArgs.push_back("-y");
+    UpperCmdArgs.push_back(Args.MakeArgString(XFlag.first));
+    UpperCmdArgs.push_back(Args.MakeArgString(XFlag.second));
+  }
+
+  // Set a -q (debug) flag for first part of Fortran frontend
+  for (Arg *A : Args.filtered(options::OPT_Hq_EQ)) {
+    A->claim();
+    StringRef Value = A->getValue();
+    auto XFlag = Value.split(",");
+    UpperCmdArgs.push_back("-q");
+    UpperCmdArgs.push_back(Args.MakeArgString(XFlag.first));
+    UpperCmdArgs.push_back(Args.MakeArgString(XFlag.second));
+  }
+
+  // Set a -qq (debug) flag for first part of Fortran frontend
+  for (Arg *A : Args.filtered(options::OPT_Hqq_EQ)) {
+    A->claim();
+    StringRef Value = A->getValue();
+    auto XFlag = Value.split(",");
+    UpperCmdArgs.push_back("-qq");
+    UpperCmdArgs.push_back(Args.MakeArgString(XFlag.first));
+    UpperCmdArgs.push_back(Args.MakeArgString(XFlag.second));
   }
 
   const char * STBFile = Args.MakeArgString(Stem + ".stb");


### PR DESCRIPTION
The compiler can generate atomic instruction to implement
OpenMP atomics; however, the compiler generates calls to
libatomic for entities that don't have corresponding atomic
instructions.  Not all systems have libatomic so this change
sets the default to continue to use a barrier for atomics until
flang adopts a named option to control atomic instructions or
flang ships its own libatomic library (or flang changes to call
the libomp atomic routines).

Also, move the handling of -Hx and -Hy options to the end of
argument processing so these options can be used to override
the compiler's defaults.