### PR TITLE
Add -Minfo, -Mneginfo flags.

### DIFF
--- a/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/include/clang/Basic/DiagnosticDriverKinds.td
@@ -202,6 +202,8 @@ def warn_drv_omp_offload_target_duplicate : Warning<
   InGroup<OpenMPTarget>;
 def err_drv_bitcode_unsupported_on_toolchain : Error<
   "-fembed-bitcode is not supported on versions of iOS prior to 6.0">;
+def err_drv_clang_unsupported_minfo_arg : Error<
+  "'%0' option does not support '%1' value">;
 
 def warn_O4_is_O3 : Warning<"-O4 is equivalent to -O3">, InGroup<Deprecated>;
 def warn_drv_optimization_value : Warning<"optimization level '%0' is not supported; using '%1%2' instead">,

--- a/include/clang/Driver/Options.td
+++ b/include/clang/Driver/Options.td
@@ -2846,6 +2846,16 @@ def Mfreeform_off: Flag<["-"], "Mnofreeform">, Group<fortran_format_Group>,
   HelpText<"Disable free-form format for Fortran">,
   Flags<[HelpHidden]>;
 
+def Minfo_EQ : CommaJoined<["-"], "Minfo=">,
+  HelpText<"Diagnostic information about successful optimizations">,
+  Values<"all,vect,inline">;
+def Minfoall : Flag<["-"], "Minfo">,
+  HelpText<"Diagnostic information about all successful optimizations">;
+def Mneginfo_EQ : CommaJoined<["-"], "Mneginfo=">,
+  HelpText<"Diagnostic information about missed optimizations">,
+  Values<"all,vect,inline">;
+def Mneginfoall : Flag<["-"], "Mneginfo">,
+  HelpText<"Diagnostic information about all missed optimizations">;
 def Mipa: Joined<["-"], "Mipa">, Group<pgi_fortran_Group>;
 def Mstackarrays: Joined<["-"], "Mstack_arrays">, Group<pgi_fortran_Group>;
 def pc: JoinedOrSeparate<["-"], "pc">, Group<pgi_fortran_Group>;

--- a/lib/Driver/ToolChains/Clang.cpp
+++ b/lib/Driver/ToolChains/Clang.cpp
@@ -3295,6 +3295,60 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
   Args.AddLastArg(CmdArgs, options::OPT_fveclib);
 #endif
 
+  std::string PassRemarkVal(""), PassRemarkOpt("");
+  if (Args.getLastArg(options::OPT_Minfoall)) {
+    PassRemarkVal = ".*";
+    Args.ClaimAllArgs(options::OPT_Minfoall);
+  } else if (Arg *A = Args.getLastArg(options::OPT_Minfo_EQ)) {
+    for (const StringRef &val : A->getValues()) {
+      if(val.equals("all")) {
+        PassRemarkVal = ".*";
+        break;
+      } else if(val.equals("inline") || val.equals("vect")) {
+        PassRemarkVal += PassRemarkVal.empty() ? "" : "|";
+        PassRemarkVal += val;
+      } else {
+        D.Diag(diag::err_drv_clang_unsupported_minfo_arg)
+          << A->getOption().getName()
+          << val.str();
+        break;
+      }
+    }
+  }
+  PassRemarkOpt = "-pass-remarks=" + PassRemarkVal;
+  CmdArgs.push_back("-mllvm");
+  CmdArgs.push_back(Args.MakeArgString(PassRemarkOpt));
+  Args.ClaimAllArgs(options::OPT_Minfo_EQ);
+  PassRemarkVal.clear();
+  PassRemarkOpt.clear();
+
+  if (Args.getLastArg(options::OPT_Mneginfoall)) {
+    PassRemarkVal = ".*";
+    Args.ClaimAllArgs(options::OPT_Mneginfoall);
+  } else if (Arg *A = Args.getLastArg(options::OPT_Mneginfo_EQ)) {
+    for (const StringRef &val : A->getValues()) {
+      if(val.equals("all")) {
+        PassRemarkVal = ".*";
+        break;
+      } else if(val.equals("inline") || val.equals("vect")) {
+        PassRemarkVal += PassRemarkVal.empty() ? "" : "|";
+        PassRemarkVal += val;
+      } else {
+        D.Diag(diag::err_drv_clang_unsupported_minfo_arg)
+          << A->getOption().getName()
+          << val.str();
+        break;
+      }
+    }
+  }
+  PassRemarkOpt = "-pass-remarks-missed=" + PassRemarkVal;
+  CmdArgs.push_back("-mllvm");
+  CmdArgs.push_back(Args.MakeArgString(PassRemarkOpt));
+  PassRemarkOpt = "-pass-remarks-analysis=" + PassRemarkVal;
+  CmdArgs.push_back("-mllvm");
+  CmdArgs.push_back(Args.MakeArgString(PassRemarkOpt));
+  Args.ClaimAllArgs(options::OPT_Mneginfo_EQ);
+  
   if (Args.hasFlag(options::OPT_fmerge_all_constants,
                    options::OPT_fno_merge_all_constants, false))
     CmdArgs.push_back("-fmerge-all-constants");


### PR DESCRIPTION
They are wrappers for already available llvm options to display diagnostic information about optimizations like vectorization, inlining and a few more.
These flags mimic the PGI -Minfo, -Mneginfo flags in behavior to the extent which it is meaningful.
Usage: 
- -M[neg]info / -M[neg]info=all (Generate informational messages about all successful [failed] optimizations)
- -M[neg]info=vect (Generate informational messages about successful [failed] loop vectorizations and simd/slp vectorizations)
- -M[neg]info=inline (Generate informational messages about successful [failed] inlinig)
-M[neg]info=inline,vect (Generate informational messages about successful [failed] loop vectorizations, simd/slp vectorizations and inlining) 