### PR TITLE
OpenMP Offload Toolchain is integrated into Flang.

### DIFF
--- a/lib/Driver/ToolChains/Cuda.cpp
+++ b/lib/Driver/ToolChains/Cuda.cpp
@@ -670,3 +670,42 @@ VersionTuple CudaToolChain::computeMSVCVersion(const Driver *D,
                                                const ArgList &Args) const {
   return HostTC.computeMSVCVersion(D, Args);
 }
+
+static void AddFlangSysIncludeArg(const ArgList &DriverArgs,
+                                  ArgStringList &Flang1Args,
+                                  ToolChain::path_list IncludePathList) {
+  std::string ArgValue; // Path argument value
+
+  // Make up argument value consisting of paths separated by colons
+  bool first = true;
+  for (auto P : IncludePathList) {
+    if (first) {
+      first = false;
+    } else {
+      ArgValue += ":";
+    }
+    ArgValue += P;
+  }
+
+  // Add the argument
+  Flang1Args.push_back("-stdinc");
+  Flang1Args.push_back(DriverArgs.MakeArgString(ArgValue));
+}
+
+void CudaToolChain::AddFlangSystemIncludeArgs(const llvm::opt::ArgList &DriverArgs,
+                                              llvm::opt::ArgStringList &Flang1Args) const {
+  path_list IncludePathList;
+  const Driver &D = getDriver();
+
+
+  if (DriverArgs.hasArg(options::OPT_nostdinc))
+    return;
+
+  {
+    SmallString<128> P(D.InstalledDir);
+    llvm::sys::path::append(P, "../include");
+    IncludePathList.push_back(P.str());
+  }
+
+  AddFlangSysIncludeArg(DriverArgs, Flang1Args, IncludePathList);
+}

--- a/lib/Driver/ToolChains/Cuda.h
+++ b/lib/Driver/ToolChains/Cuda.h
@@ -183,6 +183,10 @@ public:
   const ToolChain &HostTC;
   CudaInstallationDetector CudaInstallation;
 
+  void
+  AddFlangSystemIncludeArgs(const llvm::opt::ArgList &DriverArgs,
+                            llvm::opt::ArgStringList &Flang1Args) const override;
+
 protected:
   Tool *buildAssembler() const override;  // ptxas
   Tool *buildLinker() const override;     // fatbinary (ok, not really a linker)

--- a/tools/clang-offload-bundler/ClangOffloadBundler.cpp
+++ b/tools/clang-offload-bundler/ClangOffloadBundler.cpp
@@ -743,6 +743,8 @@ static FileHandler *CreateFileHandler(MemoryBuffer &FirstInput) {
     return new TextFileHandler(/*Comment=*/"//");
   if (FilesType == "ll")
     return new TextFileHandler(/*Comment=*/";");
+  if (FilesType == "f95")
+    return new TextFileHandler(/*Comment=*/"!");
   if (FilesType == "bc")
     return new BinaryFileHandler();
   if (FilesType == "s")


### PR DESCRIPTION
The patch has several purposes. First, it enables OpenMP Offload Toolchain for Flang when "fopenmp-target = <llvm-target-triple>" is used. Then, the necessary parameters to create a device code are passed to flang1 and flang2. It also introduces Fortran extensions to the clang-offload-bundler tool because it is being used during unloading.