### PR TITLE
OpenMP NVIDIA offload toolchain integration to Flang.

### DIFF
--- a/lib/Driver/ToolChains/Cuda.cpp
+++ b/lib/Driver/ToolChains/Cuda.cpp
@@ -830,3 +830,42 @@ VersionTuple CudaToolChain::computeMSVCVersion(const Driver *D,
                                                const ArgList &Args) const {
   return HostTC.computeMSVCVersion(D, Args);
 }
+
+static void AddFlangSysIncludeArg(const ArgList &DriverArgs,
+                                  ArgStringList &Flang1Args,
+                                  ToolChain::path_list IncludePathList) {
+  std::string ArgValue; // Path argument value
+
+  // Make up argument value consisting of paths separated by colons
+  bool first = true;
+  for (auto P : IncludePathList) {
+    if (first) {
+      first = false;
+    } else {
+      ArgValue += ":";
+    }
+    ArgValue += P;
+  }
+
+  // Add the argument
+  Flang1Args.push_back("-stdinc");
+  Flang1Args.push_back(DriverArgs.MakeArgString(ArgValue));
+}
+
+void CudaToolChain::AddFlangSystemIncludeArgs(const llvm::opt::ArgList &DriverArgs,
+                                              llvm::opt::ArgStringList &Flang1Args) const {
+  path_list IncludePathList;
+  const Driver &D = getDriver();
+
+
+  if (DriverArgs.hasArg(options::OPT_nostdinc))
+    return;
+
+  {
+    SmallString<128> P(D.InstalledDir);
+    llvm::sys::path::append(P, "../include");
+    IncludePathList.push_back(P.str());
+  }
+
+  AddFlangSysIncludeArg(DriverArgs, Flang1Args, IncludePathList);
+}

--- a/lib/Driver/ToolChains/Cuda.cpp
+++ b/lib/Driver/ToolChains/Cuda.cpp
@@ -856,16 +856,10 @@ void CudaToolChain::AddFlangSystemIncludeArgs(const llvm::opt::ArgList &DriverAr
                                               llvm::opt::ArgStringList &Flang1Args) const {
   path_list IncludePathList;
   const Driver &D = getDriver();
-
-
   if (DriverArgs.hasArg(options::OPT_nostdinc))
     return;
-
-  {
-    SmallString<128> P(D.InstalledDir);
-    llvm::sys::path::append(P, "../include");
-    IncludePathList.push_back(P.str());
-  }
-
+  SmallString<128> P(D.InstalledDir);
+  llvm::sys::path::append(P, "../include");
+  IncludePathList.push_back(P.str());
   AddFlangSysIncludeArg(DriverArgs, Flang1Args, IncludePathList);
 }

--- a/lib/Driver/ToolChains/Cuda.h
+++ b/lib/Driver/ToolChains/Cuda.h
@@ -186,6 +186,9 @@ public:
   const ToolChain &HostTC;
   CudaInstallationDetector CudaInstallation;
 
+  void
+  AddFlangSystemIncludeArgs(const llvm::opt::ArgList &DriverArgs,
+                            llvm::opt::ArgStringList &Flang1Args) const override;
 protected:
   Tool *buildAssembler() const override;  // ptxas
   Tool *buildLinker() const override;     // fatbinary (ok, not really a linker)

--- a/lib/Driver/ToolChains/Flang.cpp
+++ b/lib/Driver/ToolChains/Flang.cpp
@@ -45,6 +45,7 @@ void FlangFrontend::ConstructJob(Compilation &C, const JobAction &JA,
   ArgStringList UpperCmdArgs;
   ArgStringList LowerCmdArgs;
   SmallString<256> Stem;
+  SmallString<256> Path;
   std::string OutFile;
   bool NeedIEEE = false;
   bool NeedFastMath = false;
@@ -52,6 +53,8 @@ void FlangFrontend::ConstructJob(Compilation &C, const JobAction &JA,
 
   // Check number of inputs for sanity. We need at least one input.
   assert(Inputs.size() >= 1 && "Must have at least one input.");
+
+  bool IsOpenMPDevice = JA.isDeviceOffloading(Action::OFK_OpenMP);
 
   /***** Process file arguments to both parts *****/
   const InputInfo &Input = Inputs[0];
@@ -792,6 +795,22 @@ void FlangFrontend::ConstructJob(Compilation &C, const JobAction &JA,
   UpperCmdArgs.push_back("-output");
   UpperCmdArgs.push_back(ILMFile);
 
+  if(Args.getAllArgValues(options::OPT_fopenmp_targets_EQ).size() > 0) {
+    SmallString<128> TargetInfo;
+    Path = llvm::sys::path::parent_path(Output.getFilename());
+    Arg* Tgts = Args.getLastArg(options::OPT_fopenmp_targets_EQ);
+    assert(Tgts && Tgts->getNumValues() &&
+           "OpenMP offloading has to have targets specified.");
+    for (unsigned i = 0; i < Tgts->getNumValues(); ++i) {
+      if (i)
+        TargetInfo += ',';
+      llvm::Triple T(Tgts->getValue(i));
+      TargetInfo += T.getTriple();
+    }
+    UpperCmdArgs.push_back("-fopenmp-targets");
+    UpperCmdArgs.push_back(Args.MakeArgString(TargetInfo.str()));
+  }
+
   C.addCommand(llvm::make_unique<Command>(JA, *this, UpperExec, UpperCmdArgs, Inputs));
 
   // For -fsyntax-only or -E that is it
@@ -899,7 +918,48 @@ void FlangFrontend::ConstructJob(Compilation &C, const JobAction &JA,
   LowerCmdArgs.push_back("-stbfile");
   LowerCmdArgs.push_back(STBFile);
 
-  LowerCmdArgs.push_back("-asm"); LowerCmdArgs.push_back(Args.MakeArgString(OutFile));
+  /* OpenMP GPU Offload */
+  if(Args.getAllArgValues(options::OPT_fopenmp_targets_EQ).size() > 0) {
+    //if (isa<CompileJobAction>(JA) && JA.isHostOffloading(Action::OFK_OpenMP)) {
+    SmallString<128> TargetInfo;//("-fopenmp-targets ");
+    SmallString<256> TargetInfoAsm;//("-fopenmp-targets-asm ");
+    Path = llvm::sys::path::parent_path(Output.getFilename());
+
+    Arg* Tgts = Args.getLastArg(options::OPT_fopenmp_targets_EQ);
+    assert(Tgts && Tgts->getNumValues() &&
+           "OpenMP offloading has to have targets specified.");
+    for (unsigned i = 0; i < Tgts->getNumValues(); ++i) {
+      if (i)
+        TargetInfo += ',';
+      // We need to get the string from the triple because it may be not exactly
+      // the same as the one we get directly from the arguments.
+      llvm::Triple T(Tgts->getValue(i));
+      TargetInfo += T.getTriple();
+      // We also need to give a output file
+      TargetInfoAsm += Path;
+      TargetInfoAsm += "/";
+      TargetInfoAsm += Stem;
+      TargetInfoAsm += "-";
+      TargetInfoAsm += T.getTriple();
+      TargetInfoAsm += ".ll";
+    }
+    LowerCmdArgs.push_back("-fopenmp-targets");
+    LowerCmdArgs.push_back(Args.MakeArgString(TargetInfo.str()));
+    if(IsOpenMPDevice) {
+      LowerCmdArgs.push_back("-fopenmp-targets-asm");
+      LowerCmdArgs.push_back(Args.MakeArgString(OutFile));
+      LowerCmdArgs.push_back("-asm");
+      LowerCmdArgs.push_back(Args.MakeArgString(TargetInfoAsm.str()));
+    } else {
+      LowerCmdArgs.push_back("-fopenmp-targets-asm");
+      LowerCmdArgs.push_back(Args.MakeArgString(TargetInfoAsm.str()));
+      LowerCmdArgs.push_back("-asm");
+      LowerCmdArgs.push_back(Args.MakeArgString(OutFile));
+    }
+  } else {
+    LowerCmdArgs.push_back("-asm");
+    LowerCmdArgs.push_back(Args.MakeArgString(OutFile));
+  }
 
   C.addCommand(llvm::make_unique<Command>(JA, *this, LowerExec, LowerCmdArgs, Inputs));
 }

--- a/tools/clang-offload-bundler/ClangOffloadBundler.cpp
+++ b/tools/clang-offload-bundler/ClangOffloadBundler.cpp
@@ -742,6 +742,8 @@ static FileHandler *CreateFileHandler(MemoryBuffer &FirstInput) {
     return new TextFileHandler(/*Comment=*/"//");
   if (FilesType == "ll")
     return new TextFileHandler(/*Comment=*/";");
+  if (FilesType == "f95")
+    return new TextFileHandler(/*Comment=*/"!");
   if (FilesType == "bc")
     return new BinaryFileHandler();
   if (FilesType == "s")


### PR DESCRIPTION
The patch has several purposes. First, it enables OpenMP Offload Toolchain for Flang when "fopenmp-target = " is used. Then, the necessary parameters to create a device code are passed to flang1 and flang2. It also introduces Fortran extensions to the clang-offload-bundler tool because it is being used during unloading.