### PR TITLE
Enable contiguous pointer checks in flang with -fsanitize option.

### DIFF
--- a/include/clang/Basic/Sanitizers.def
+++ b/include/clang/Basic/Sanitizers.def
@@ -93,6 +93,8 @@ SANITIZER("signed-integer-overflow", SignedIntegerOverflow)
 SANITIZER("unreachable", Unreachable)
 SANITIZER("vla-bound", VLABound)
 SANITIZER("vptr", Vptr)
+// fortran contiguous pointer checks
+SANITIZER("discontiguous", Discontiguous)
 
 // IntegerSanitizer
 SANITIZER("unsigned-integer-overflow", UnsignedIntegerOverflow)

--- a/lib/Driver/ToolChains/Flang.cpp
+++ b/lib/Driver/ToolChains/Flang.cpp
@@ -185,6 +185,25 @@ void FlangFrontend::ConstructJob(Compilation &C, const JobAction &JA,
     CommonCmdArgs.push_back("2");
   }
 
+  // Contiguous pointer checks
+  if (Arg *A = Args.getLastArg(options::OPT_fsanitize_EQ)) {
+    for (const StringRef &val : A->getValues()) {
+      if (val.equals("discontiguous") || val.equals("undefined") ) {
+        // -x 54 0x40 -x 54 0x80 -x 54 0x200
+        UpperCmdArgs.push_back("-x");
+        UpperCmdArgs.push_back("54");
+        UpperCmdArgs.push_back("0x2c0");
+
+        // -fsanitze=discontiguous has no meaning in LLVM, only flang driver needs to
+        // recognize it. However -fsanitize=undefined needs to be passed on for further
+        // processing by the non-flang part of the driver.
+        if (val.equals("discontiguous"))
+          A->claim();
+        break;
+      }
+    }
+  }
+
   // Treat backslashes as regular characters
   for (auto Arg : Args.filtered(options::OPT_fnobackslash, options::OPT_Mbackslash)) {
     Arg->claim();


### PR DESCRIPTION
Allow -fsanitize=discontiguous and -fsanitize=undefined to generate -Hx,54,0x2c0 which enables:

1. Checking of contiguous pointer assignments and contiguous pointer dummy arguments inside callees (-Hx,54,0x40)
2. Checking the actual argument associated with a contiguous pointer dummy argument at a call-site (-Hx,54,0x80)
3. Do not flag null pointer targets as noncontiguous (-Hx,54,0x200)