### PR TITLE
Enable contiguous pointer checks in flang with -fsanitize option.

### DIFF
--- a/include/clang/Basic/Sanitizers.def
+++ b/include/clang/Basic/Sanitizers.def
@@ -89,6 +89,8 @@ SANITIZER("signed-integer-overflow", SignedIntegerOverflow)
 SANITIZER("unreachable", Unreachable)
 SANITIZER("vla-bound", VLABound)
 SANITIZER("vptr", Vptr)
+// fortran contiguous pointer checks
+SANITIZER("discontiguous", Discontiguous)
 
 // IntegerSanitizer
 SANITIZER("unsigned-integer-overflow", UnsignedIntegerOverflow)


### PR DESCRIPTION
Needs to go in after [this](https://github.com/flang-compiler/flang-driver/pull/57) is approved. 