### PR TITLE
add support for -Mwritable-constants to flang.

### DIFF
--- a/include/clang/Driver/Options.td
+++ b/include/clang/Driver/Options.td
@@ -2880,6 +2880,8 @@ def Mpreprocess : Flag<["-"], "Mpreprocess">, Group<pgi_fortran_Group>,
 def Mstandard: Flag<["-"], "Mstandard">, Group<pgi_fortran_Group>,
   HelpText<"Check Fortran standard conformance">;
 def Mchkptr: Flag<["-"], "Mchkptr">, Group<pgi_fortran_Group>;
+def Mwritable_constants: Flag<["-"], "Mwritable-constants">, Group<pgi_fortran_Group>,
+  HelpText<"Store constants in the writable data segment">;
 defm Minline: BooleanMFlag<"inline">, Group<pgi_fortran_Group>;
 def fma: Flag<["-"], "fma">, Group<pgi_fortran_Group>,
   HelpText<"Enable generation of FMA instructions">;

--- a/lib/Driver/ToolChains/Flang.cpp
+++ b/lib/Driver/ToolChains/Flang.cpp
@@ -140,6 +140,14 @@ void FlangFrontend::ConstructJob(Compilation &C, const JobAction &JA,
     CommonCmdArgs.push_back("0x400");
   }
 
+  // Store constants in writable data segment
+  for (auto Arg : Args.filtered(options::OPT_Mwritable_constants)) {
+    Arg->claim();
+    LowerCmdArgs.push_back("-x");
+    LowerCmdArgs.push_back("183");
+    LowerCmdArgs.push_back("0x20000000");
+  }
+
   // Bounds checking: On
   for (auto Arg : Args.filtered(options::OPT_Mbounds_on)) {
     Arg->claim();


### PR DESCRIPTION
Add support for -Mwritable-constants to flang. Need to change "-" to "_" to avoid build failure.