### PR TITLE
Add command line option -Memit-dwarf-common-blocks-name.

### DIFF
--- a/include/clang/Driver/Options.td
+++ b/include/clang/Driver/Options.td
@@ -3143,6 +3143,8 @@ def Mnomain: Flag<["-"], "Mnomain">, Group<pgi_fortran_Group>,
   HelpText<"Don't link in Fortran main">;
 def frelaxed_math : Flag<["-"], "frelaxed-math">, Group<pgi_fortran_Group>,
   HelpText<"Use relaxed Math intrinsic functions">;
+def Memit_dwarf_common_blocks_name: Flag<["-"], "Memit-dwarf-common-blocks-name">,
+  Group<pgi_fortran_Group>, HelpText<"Emit COMMON blocks name in DWARF">;
 
 // Flang internal debug options
 def Mx_EQ : Joined<["-"], "Mx,">, Group<pgi_fortran_Group>;

--- a/lib/Driver/ToolChains/Flang.cpp
+++ b/lib/Driver/ToolChains/Flang.cpp
@@ -286,6 +286,14 @@ void FlangFrontend::ConstructJob(Compilation &C, const JobAction &JA,
     CommonCmdArgs.push_back("8");
   }
 
+  // -Memit-dwarf-common-blocks-name, only add xbit to flang2.
+  for (auto Arg : Args.filtered(options::OPT_Memit_dwarf_common_blocks_name)) {
+    Arg->claim();
+    LowerCmdArgs.push_back("-x");
+    LowerCmdArgs.push_back("183");
+    LowerCmdArgs.push_back("0x40000000");
+  }
+
   // -g should produce DWARFv2
   for (auto Arg : Args.filtered(options::OPT_g_Flag)) {
     Arg->claim();


### PR DESCRIPTION
Add control over the emitting of empty name for !DIGlobalVariable metadata node. This works around a
known bug of some specific old gdb version, e.g. 7.2-90.el6.