### PR TITLE
Use predefined macros from clang preprocessor

### DIFF
--- a/include/clang/Basic/MacroBuilder.h
+++ b/include/clang/Basic/MacroBuilder.h
@@ -27,7 +27,7 @@ public:
   MacroBuilder(raw_ostream &Output) : Out(Output) {}
 
   /// Append a \#define line for macro of the form "\#define Name Value\n".
-  void defineMacro(const Twine &Name, const Twine &Value = "1") {
+  virtual void defineMacro(const Twine &Name, const Twine &Value = "1") {
     Out << "#define " << Name << ' ' << Value << '\n';
   }
 

--- a/include/clang/Frontend/Utils.h
+++ b/include/clang/Frontend/Utils.h
@@ -15,6 +15,7 @@
 #define LLVM_CLANG_FRONTEND_UTILS_H
 
 #include "clang/Basic/Diagnostic.h"
+#include "clang/Basic/TargetInfo.h"
 #include "clang/Basic/VirtualFileSystem.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/StringRef.h"
@@ -46,13 +47,14 @@ class HeaderSearch;
 class HeaderSearchOptions;
 class IdentifierTable;
 class LangOptions;
+class MacroBuilder;
 class PCHContainerReader;
 class Preprocessor;
 class PreprocessorOptions;
 class PreprocessorOutputOptions;
 class SourceManager;
 class Stmt;
-class TargetInfo;
+class StringRef;
 class FrontendOptions;
 
 /// Apply the header search options to get given HeaderSearch object.
@@ -66,6 +68,17 @@ void ApplyHeaderSearchOptions(HeaderSearch &HS,
 void InitializePreprocessor(Preprocessor &PP, const PreprocessorOptions &PPOpts,
                             const PCHContainerReader &PCHContainerRdr,
                             const FrontendOptions &FEOpts);
+
+/// DefineTypeSize - An overloaded helper that uses TargetInfo to determine
+/// the width, suffix, and signedness of the given type
+void DefineTypeSize(const Twine &MacroName, TargetInfo::IntType Ty,
+                    const TargetInfo &TI, MacroBuilder &Builder);
+
+/// DefineTypeSize - Emit a macro to the predefines buffer that declares a macro
+/// named MacroName with the max value for a type with width 'TypeWidth' a
+/// signedness of 'isSigned' and with a value suffix of 'ValSuffix' (e.g. LL).
+void DefineTypeSize(const Twine &MacroName, unsigned TypeWidth,
+                    StringRef ValSuffix, bool isSigned, MacroBuilder &Builder);
 
 /// DoPrintPreprocessedInput - Implement -E mode.
 void DoPrintPreprocessedInput(Preprocessor &PP, raw_ostream* OS,

--- a/lib/Driver/ToolChains/Flang.cpp
+++ b/lib/Driver/ToolChains/Flang.cpp
@@ -12,13 +12,18 @@
 #include "InputInfo.h"
 #include "clang/Basic/CharInfo.h"
 #include "clang/Basic/LangOptions.h"
+#include "clang/Basic/MacroBuilder.h"
 #include "clang/Basic/ObjCRuntime.h"
+#include "clang/Basic/TargetInfo.h"
+#include "clang/Basic/TargetOptions.h"
 #include "clang/Basic/Version.h"
 #include "clang/Config/config.h"
 #include "clang/Driver/DriverDiagnostic.h"
 #include "clang/Driver/Options.h"
 #include "clang/Driver/SanitizerArgs.h"
 #include "clang/Driver/XRayArgs.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/Utils.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Option/ArgList.h"
 #include "llvm/Support/CodeGen.h"
@@ -37,6 +42,19 @@ using namespace clang::driver;
 using namespace clang::driver::tools;
 using namespace clang;
 using namespace llvm::opt;
+
+class FlangMacroBuilder : public MacroBuilder {
+  ArgStringList &CmdArgs;
+  const ArgList &DriverArgs;
+  public:
+    FlangMacroBuilder(ArgStringList &UpperCmdArgs, const ArgList &DriverArgs, llvm::raw_string_ostream &Output)
+      : MacroBuilder(Output), CmdArgs(UpperCmdArgs), DriverArgs(DriverArgs) {
+    }
+    virtual void defineMacro(const Twine &Name, const Twine &Value = "1") {
+      CmdArgs.push_back("-def");
+      CmdArgs.push_back(DriverArgs.MakeArgString(Name + Twine('=') + Value));
+    }
+};
 
 void FlangFrontend::ConstructJob(Compilation &C, const JobAction &JA,
                          const InputInfo &Output, const InputInfoList &Inputs,
@@ -600,27 +618,51 @@ void FlangFrontend::ConstructJob(Compilation &C, const JobAction &JA,
   // Add system include arguments.
   getToolChain().AddFlangSystemIncludeArgs(Args, UpperCmdArgs);
 
-  UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("unix");
-  UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__unix");
-  UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__unix__");
-  UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("linux");
-  UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__linux");
-  UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__linux__");
-  UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__NO_MATH_INLINES");
-  UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__LP64__");
-  UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__LONG_MAX__=9223372036854775807L");
-  UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__SIZE_TYPE__=unsigned long int");
-  UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__PTRDIFF_TYPE__=long int");
+  // Use clang's predefined macros
+  DiagnosticsEngine DE(new DiagnosticIDs(), new DiagnosticOptions, new IgnoringDiagConsumer());
+  std::shared_ptr<clang::TargetOptions> TO = std::make_shared<clang::TargetOptions>();
+  TO->Triple = getToolChain().getEffectiveTriple().getTriple();
+  std::shared_ptr<TargetInfo> TI(clang::TargetInfo::CreateTargetInfo(DE, TO));
+  std::string PredefineBuffer;
+  llvm::raw_string_ostream Predefines(PredefineBuffer);
+  FlangMacroBuilder Builder(UpperCmdArgs, Args, Predefines);
+
+  LangOptions LO;
+  VersionTuple VT = getToolChain().computeMSVCVersion(&getToolChain().getDriver(), Args);
+  if (!VT.empty()) {
+    // Set the MSCompatibility version. Subminor version has 5 decimal digits.
+    // Minor and major versions have 2 decimal digits each.
+    LO.MSCompatibilityVersion = VT.getMajor() * 10000000 +
+                                VT.getMinor().getValueOr(0) * 100000 +
+                                VT.getSubminor().getValueOr(0);
+  }
+
+  // Define Target specific macros like __linux__
+  TI->getTargetDefines(LO, Builder);
+
+  Builder.defineMacro("__SIZE_TYPE__", TargetInfo::getTypeName(TI->getSizeType()));
+  Builder.defineMacro("__PTRDIFF_TYPE__", TargetInfo::getTypeName(TI->getPtrDiffType(0)));
+
+  if (TI->getPointerWidth(0) == 64 && TI->getLongWidth() == 64
+      && TI->getIntWidth() == 32) {
+    Builder.defineMacro("_LP64");
+    Builder.defineMacro("__LP64__");
+  }
+
+  if (TI->getPointerWidth(0) == 32 && TI->getLongWidth() == 32
+      && TI->getIntWidth() == 32) {
+    Builder.defineMacro("_ILP32");
+    Builder.defineMacro("__ILP32__");
+  }
+
+  DefineTypeSize("__LONG_MAX__", TargetInfo::SignedLong, *TI, Builder);
+
+  // Add additional predefined macros
   switch (getToolChain().getEffectiveTriple().getArch()) {
   case llvm::Triple::aarch64:
-    UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__aarch64");
-    UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__aarch64__");
-    UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__ARM_ARCH=8");
     UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__ARM_ARCH__=8");
     break;
   case llvm::Triple::x86_64:
-    UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__x86_64");
-    UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__x86_64__");
     UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__amd_64__amd64__");
     UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__k8");
     UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__k8__");

--- a/lib/Frontend/InitPreprocessor.cpp
+++ b/lib/Frontend/InitPreprocessor.cpp
@@ -181,7 +181,7 @@ static void DefineFloatMacros(MacroBuilder &Builder, StringRef Prefix,
 /// DefineTypeSize - Emit a macro to the predefines buffer that declares a macro
 /// named MacroName with the max value for a type with width 'TypeWidth' a
 /// signedness of 'isSigned' and with a value suffix of 'ValSuffix' (e.g. LL).
-static void DefineTypeSize(const Twine &MacroName, unsigned TypeWidth,
+void clang::DefineTypeSize(const Twine &MacroName, unsigned TypeWidth,
                            StringRef ValSuffix, bool isSigned,
                            MacroBuilder &Builder) {
   llvm::APInt MaxVal = isSigned ? llvm::APInt::getSignedMaxValue(TypeWidth)
@@ -191,7 +191,7 @@ static void DefineTypeSize(const Twine &MacroName, unsigned TypeWidth,
 
 /// DefineTypeSize - An overloaded helper that uses TargetInfo to determine
 /// the width, suffix, and signedness of the given type
-static void DefineTypeSize(const Twine &MacroName, TargetInfo::IntType Ty,
+void clang::DefineTypeSize(const Twine &MacroName, TargetInfo::IntType Ty,
                            const TargetInfo &TI, MacroBuilder &Builder) {
   DefineTypeSize(MacroName, TI.getTypeWidth(Ty), TI.getTypeConstantSuffix(Ty),
                  TI.isTypeSigned(Ty), Builder);


### PR DESCRIPTION
Here's the list of symbols clang defines on linux x86_64

```
__llvm__ 1
__clang__ 1
__clang_major__ 6
__clang_minor__ 0
__clang_patchlevel__ 1
__clang_version__ "6.0.1 "
__GNUC_MINOR__ 2
__GNUC_PATCHLEVEL__ 1
__GNUC__ 4
__GXX_ABI_VERSION 1002
__ATOMIC_RELAXED 0
__ATOMIC_CONSUME 1
__ATOMIC_ACQUIRE 2
__ATOMIC_RELEASE 3
__ATOMIC_ACQ_REL 4
__ATOMIC_SEQ_CST 5
__OPENCL_MEMORY_SCOPE_WORK_ITEM 0
__OPENCL_MEMORY_SCOPE_WORK_GROUP 1
__OPENCL_MEMORY_SCOPE_DEVICE 2
__OPENCL_MEMORY_SCOPE_ALL_SVM_DEVICES 3
__OPENCL_MEMORY_SCOPE_SUB_GROUP 4
__PRAGMA_REDEFINE_EXTNAME 1
__VERSION__ "4.2.1 Compatible Clang 6.0.1 "
__OBJC_BOOL_IS_BOOL 0
__CONSTANT_CFSTRINGS__ 1
__GXX_RTTI 1
__ORDER_LITTLE_ENDIAN__ 1234
__ORDER_BIG_ENDIAN__ 4321
__ORDER_PDP_ENDIAN__ 3412
__BYTE_ORDER__ __ORDER_LITTLE_ENDIAN__
__LITTLE_ENDIAN__ 1
_LP64 1
__LP64__ 1
__CHAR_BIT__ 8
__SCHAR_MAX__ 127
__SHRT_MAX__ 32767
__INT_MAX__ 2147483647
__LONG_MAX__ 9223372036854775807L
__LONG_LONG_MAX__ 9223372036854775807LL
__WCHAR_MAX__ 2147483647
__WINT_MAX__ 4294967295U
__INTMAX_MAX__ 9223372036854775807L
__SIZE_MAX__ 18446744073709551615UL
__UINTMAX_MAX__ 18446744073709551615UL
__PTRDIFF_MAX__ 9223372036854775807L
__INTPTR_MAX__ 9223372036854775807L
__UINTPTR_MAX__ 18446744073709551615UL
__SIZEOF_DOUBLE__ 8
__SIZEOF_FLOAT__ 4
__SIZEOF_INT__ 4
__SIZEOF_LONG__ 8
__SIZEOF_LONG_DOUBLE__ 16
__SIZEOF_LONG_LONG__ 8
__SIZEOF_POINTER__ 8
__SIZEOF_SHORT__ 2
__SIZEOF_PTRDIFF_T__ 8
__SIZEOF_SIZE_T__ 8
__SIZEOF_WCHAR_T__ 4
__SIZEOF_WINT_T__ 4
__SIZEOF_INT128__ 16
__INTMAX_TYPE__ long int
__INTMAX_FMTd__ "ld"
__INTMAX_FMTi__ "li"
__INTMAX_C_SUFFIX__ L
__UINTMAX_TYPE__ long unsigned int
__UINTMAX_FMTo__ "lo"
__UINTMAX_FMTu__ "lu"
__UINTMAX_FMTx__ "lx"
__UINTMAX_FMTX__ "lX"
__UINTMAX_C_SUFFIX__ UL
__INTMAX_WIDTH__ 64
__PTRDIFF_TYPE__ long int
__PTRDIFF_FMTd__ "ld"
__PTRDIFF_FMTi__ "li"
__PTRDIFF_WIDTH__ 64
__INTPTR_TYPE__ long int
__INTPTR_FMTd__ "ld"
__INTPTR_FMTi__ "li"
__INTPTR_WIDTH__ 64
__SIZE_TYPE__ long unsigned int
__SIZE_FMTo__ "lo"
__SIZE_FMTu__ "lu"
__SIZE_FMTx__ "lx"
__SIZE_FMTX__ "lX"
__SIZE_WIDTH__ 64
__WCHAR_TYPE__ int
__WCHAR_WIDTH__ 32
__WINT_TYPE__ unsigned int
__WINT_WIDTH__ 32
__SIG_ATOMIC_WIDTH__ 32
__SIG_ATOMIC_MAX__ 2147483647
__CHAR16_TYPE__ unsigned short
__CHAR32_TYPE__ unsigned int
__UINTMAX_WIDTH__ 64
__UINTPTR_TYPE__ long unsigned int
__UINTPTR_FMTo__ "lo"
__UINTPTR_FMTu__ "lu"
__UINTPTR_FMTx__ "lx"
__UINTPTR_FMTX__ "lX"
__UINTPTR_WIDTH__ 64
__FLT16_DENORM_MIN__ 5.9604644775390625e-8F16
__FLT16_HAS_DENORM__ 1
__FLT16_DIG__ 3
__FLT16_DECIMAL_DIG__ 5
__FLT16_EPSILON__ 9.765625e-4F16
__FLT16_HAS_INFINITY__ 1
__FLT16_HAS_QUIET_NAN__ 1
__FLT16_MANT_DIG__ 11
__FLT16_MAX_10_EXP__ 4
__FLT16_MAX_EXP__ 15
__FLT16_MAX__ 6.5504e+4F16
__FLT16_MIN_10_EXP__ (-13)
__FLT16_MIN_EXP__ (-14)
__FLT16_MIN__ 6.103515625e-5F16
__FLT_DENORM_MIN__ 1.40129846e-45F
__FLT_HAS_DENORM__ 1
__FLT_DIG__ 6
__FLT_DECIMAL_DIG__ 9
__FLT_EPSILON__ 1.19209290e-7F
__FLT_HAS_INFINITY__ 1
__FLT_HAS_QUIET_NAN__ 1
__FLT_MANT_DIG__ 24
__FLT_MAX_10_EXP__ 38
__FLT_MAX_EXP__ 128
__FLT_MAX__ 3.40282347e+38F
__FLT_MIN_10_EXP__ (-37)
__FLT_MIN_EXP__ (-125)
__FLT_MIN__ 1.17549435e-38F
__DBL_DENORM_MIN__ 4.9406564584124654e-324
__DBL_HAS_DENORM__ 1
__DBL_DIG__ 15
__DBL_DECIMAL_DIG__ 17
__DBL_EPSILON__ 2.2204460492503131e-16
__DBL_HAS_INFINITY__ 1
__DBL_HAS_QUIET_NAN__ 1
__DBL_MANT_DIG__ 53
__DBL_MAX_10_EXP__ 308
__DBL_MAX_EXP__ 1024
__DBL_MAX__ 1.7976931348623157e+308
__DBL_MIN_10_EXP__ (-307)
__DBL_MIN_EXP__ (-1021)
__DBL_MIN__ 2.2250738585072014e-308
__LDBL_DENORM_MIN__ 3.64519953188247460253e-4951L
__LDBL_HAS_DENORM__ 1
__LDBL_DIG__ 18
__LDBL_DECIMAL_DIG__ 21
__LDBL_EPSILON__ 1.08420217248550443401e-19L
__LDBL_HAS_INFINITY__ 1
__LDBL_HAS_QUIET_NAN__ 1
__LDBL_MANT_DIG__ 64
__LDBL_MAX_10_EXP__ 4932
__LDBL_MAX_EXP__ 16384
__LDBL_MAX__ 1.18973149535723176502e+4932L
__LDBL_MIN_10_EXP__ (-4931)
__LDBL_MIN_EXP__ (-16381)
__LDBL_MIN__ 3.36210314311209350626e-4932L
__POINTER_WIDTH__ 64
__BIGGEST_ALIGNMENT__ 16
__WINT_UNSIGNED__ 1
__INT8_TYPE__ signed char
__INT8_FMTd__ "hhd"
__INT8_FMTi__ "hhi"
__INT8_C_SUFFIX__ 
__INT16_TYPE__ short
__INT16_FMTd__ "hd"
__INT16_FMTi__ "hi"
__INT16_C_SUFFIX__ 
__INT32_TYPE__ int
__INT32_FMTd__ "d"
__INT32_FMTi__ "i"
__INT32_C_SUFFIX__ 
__INT64_TYPE__ long int
__INT64_FMTd__ "ld"
__INT64_FMTi__ "li"
__INT64_C_SUFFIX__ L
__UINT8_TYPE__ unsigned char
__UINT8_FMTo__ "hho"
__UINT8_FMTu__ "hhu"
__UINT8_FMTx__ "hhx"
__UINT8_FMTX__ "hhX"
__UINT8_C_SUFFIX__ 
__UINT8_MAX__ 255
__INT8_MAX__ 127
__UINT16_TYPE__ unsigned short
__UINT16_FMTo__ "ho"
__UINT16_FMTu__ "hu"
__UINT16_FMTx__ "hx"
__UINT16_FMTX__ "hX"
__UINT16_C_SUFFIX__ 
__UINT16_MAX__ 65535
__INT16_MAX__ 32767
__UINT32_TYPE__ unsigned int
__UINT32_FMTo__ "o"
__UINT32_FMTu__ "u"
__UINT32_FMTx__ "x"
__UINT32_FMTX__ "X"
__UINT32_C_SUFFIX__ U
__UINT32_MAX__ 4294967295U
__INT32_MAX__ 2147483647
__UINT64_TYPE__ long unsigned int
__UINT64_FMTo__ "lo"
__UINT64_FMTu__ "lu"
__UINT64_FMTx__ "lx"
__UINT64_FMTX__ "lX"
__UINT64_C_SUFFIX__ UL
__UINT64_MAX__ 18446744073709551615UL
__INT64_MAX__ 9223372036854775807L
__INT_LEAST8_TYPE__ signed char
__INT_LEAST8_MAX__ 127
__INT_LEAST8_FMTd__ "hhd"
__INT_LEAST8_FMTi__ "hhi"
__UINT_LEAST8_TYPE__ unsigned char
__UINT_LEAST8_MAX__ 255
__UINT_LEAST8_FMTo__ "hho"
__UINT_LEAST8_FMTu__ "hhu"
__UINT_LEAST8_FMTx__ "hhx"
__UINT_LEAST8_FMTX__ "hhX"
__INT_LEAST16_TYPE__ short
__INT_LEAST16_MAX__ 32767
__INT_LEAST16_FMTd__ "hd"
__INT_LEAST16_FMTi__ "hi"
__UINT_LEAST16_TYPE__ unsigned short
__UINT_LEAST16_MAX__ 65535
__UINT_LEAST16_FMTo__ "ho"
__UINT_LEAST16_FMTu__ "hu"
__UINT_LEAST16_FMTx__ "hx"
__UINT_LEAST16_FMTX__ "hX"
__INT_LEAST32_TYPE__ int
__INT_LEAST32_MAX__ 2147483647
__INT_LEAST32_FMTd__ "d"
__INT_LEAST32_FMTi__ "i"
__UINT_LEAST32_TYPE__ unsigned int
__UINT_LEAST32_MAX__ 4294967295U
__UINT_LEAST32_FMTo__ "o"
__UINT_LEAST32_FMTu__ "u"
__UINT_LEAST32_FMTx__ "x"
__UINT_LEAST32_FMTX__ "X"
__INT_LEAST64_TYPE__ long int
__INT_LEAST64_MAX__ 9223372036854775807L
__INT_LEAST64_FMTd__ "ld"
__INT_LEAST64_FMTi__ "li"
__UINT_LEAST64_TYPE__ long unsigned int
__UINT_LEAST64_MAX__ 18446744073709551615UL
__UINT_LEAST64_FMTo__ "lo"
__UINT_LEAST64_FMTu__ "lu"
__UINT_LEAST64_FMTx__ "lx"
__UINT_LEAST64_FMTX__ "lX"
__INT_FAST8_TYPE__ signed char
__INT_FAST8_MAX__ 127
__INT_FAST8_FMTd__ "hhd"
__INT_FAST8_FMTi__ "hhi"
__UINT_FAST8_TYPE__ unsigned char
__UINT_FAST8_MAX__ 255
__UINT_FAST8_FMTo__ "hho"
__UINT_FAST8_FMTu__ "hhu"
__UINT_FAST8_FMTx__ "hhx"
__UINT_FAST8_FMTX__ "hhX"
__INT_FAST16_TYPE__ short
__INT_FAST16_MAX__ 32767
__INT_FAST16_FMTd__ "hd"
__INT_FAST16_FMTi__ "hi"
__UINT_FAST16_TYPE__ unsigned short
__UINT_FAST16_MAX__ 65535
__UINT_FAST16_FMTo__ "ho"
__UINT_FAST16_FMTu__ "hu"
__UINT_FAST16_FMTx__ "hx"
__UINT_FAST16_FMTX__ "hX"
__INT_FAST32_TYPE__ int
__INT_FAST32_MAX__ 2147483647
__INT_FAST32_FMTd__ "d"
__INT_FAST32_FMTi__ "i"
__UINT_FAST32_TYPE__ unsigned int
__UINT_FAST32_MAX__ 4294967295U
__UINT_FAST32_FMTo__ "o"
__UINT_FAST32_FMTu__ "u"
__UINT_FAST32_FMTx__ "x"
__UINT_FAST32_FMTX__ "X"
__INT_FAST64_TYPE__ long int
__INT_FAST64_MAX__ 9223372036854775807L
__INT_FAST64_FMTd__ "ld"
__INT_FAST64_FMTi__ "li"
__UINT_FAST64_TYPE__ long unsigned int
__UINT_FAST64_MAX__ 18446744073709551615UL
__UINT_FAST64_FMTo__ "lo"
__UINT_FAST64_FMTu__ "lu"
__UINT_FAST64_FMTx__ "lx"
__UINT_FAST64_FMTX__ "lX"
__USER_LABEL_PREFIX__ 
__FINITE_MATH_ONLY__ 0
__GNUC_STDC_INLINE__ 1
__GCC_ATOMIC_TEST_AND_SET_TRUEVAL 1
__CLANG_ATOMIC_BOOL_LOCK_FREE 2
__CLANG_ATOMIC_CHAR_LOCK_FREE 2
__CLANG_ATOMIC_CHAR16_T_LOCK_FREE 2
__CLANG_ATOMIC_CHAR32_T_LOCK_FREE 2
__CLANG_ATOMIC_WCHAR_T_LOCK_FREE 2
__CLANG_ATOMIC_SHORT_LOCK_FREE 2
__CLANG_ATOMIC_INT_LOCK_FREE 2
__CLANG_ATOMIC_LONG_LOCK_FREE 2
__CLANG_ATOMIC_LLONG_LOCK_FREE 2
__CLANG_ATOMIC_POINTER_LOCK_FREE 2
__GCC_ATOMIC_BOOL_LOCK_FREE 2
__GCC_ATOMIC_CHAR_LOCK_FREE 2
__GCC_ATOMIC_CHAR16_T_LOCK_FREE 2
__GCC_ATOMIC_CHAR32_T_LOCK_FREE 2
__GCC_ATOMIC_WCHAR_T_LOCK_FREE 2
__GCC_ATOMIC_SHORT_LOCK_FREE 2
__GCC_ATOMIC_INT_LOCK_FREE 2
__GCC_ATOMIC_LONG_LOCK_FREE 2
__GCC_ATOMIC_LLONG_LOCK_FREE 2
__GCC_ATOMIC_POINTER_LOCK_FREE 2
__FLT_EVAL_METHOD__ 0
__FLT_RADIX__ 2
__DECIMAL_DIG__ __LDBL_DECIMAL_DIG__
__amd64__ 1
__amd64 1
__x86_64 1
__x86_64__ 1
__REGISTER_PREFIX__ 
__NO_MATH_INLINES 1
__SSE2__ 1
__SSE2_MATH__ 1
__SSE__ 1
__SSE_MATH__ 1
__MMX__ 1
__SIZEOF_FLOAT128__ 16
unix 1
__unix 1
__unix__ 1
linux 1
__linux 1
__linux__ 1
__gnu_linux__ 1
__ELF__ 1
__FLOAT128__ 1
```