### PR TITLE
Fix github issues #747, #779

### DIFF
--- a/lib/Frontend/InitPreprocessor.cpp
+++ b/lib/Frontend/InitPreprocessor.cpp
@@ -159,26 +159,6 @@ static void DefineFloatMacros(MacroBuilder &Builder, StringRef Prefix,
   Builder.defineMacro(DefPrefix + "MIN__", Twine(Min)+Ext);
 }
 
-
-/// DefineTypeSize - Emit a macro to the predefines buffer that declares a macro
-/// named MacroName with the max value for a type with width 'TypeWidth' a
-/// signedness of 'isSigned' and with a value suffix of 'ValSuffix' (e.g. LL).
-void clang::DefineTypeSize(const Twine &MacroName, unsigned TypeWidth,
-                           StringRef ValSuffix, bool isSigned,
-                           MacroBuilder &Builder) {
-  llvm::APInt MaxVal = isSigned ? llvm::APInt::getSignedMaxValue(TypeWidth)
-                                : llvm::APInt::getMaxValue(TypeWidth);
-  Builder.defineMacro(MacroName, MaxVal.toString(10, isSigned) + ValSuffix);
-}
-
-/// DefineTypeSize - An overloaded helper that uses TargetInfo to determine
-/// the width, suffix, and signedness of the given type
-void clang::DefineTypeSize(const Twine &MacroName, TargetInfo::IntType Ty,
-                           const TargetInfo &TI, MacroBuilder &Builder) {
-  DefineTypeSize(MacroName, TI.getTypeWidth(Ty), TI.getTypeConstantSuffix(Ty),
-                 TI.isTypeSigned(Ty), Builder);
-}
-
 static void DefineFmt(const Twine &Prefix, TargetInfo::IntType Ty,
                       const TargetInfo &TI, MacroBuilder &Builder) {
   bool IsSigned = TI.isTypeSigned(Ty);


### PR DESCRIPTION
Fixes https://github.com/flang-compiler/flang/issues/747
    1. Move DefineTypeSize to include/clang/Frontend/Utils.h
    2. Make the function(s) templated so that they are instatiated at call site and not every file that includes Utils.h
    3. Having this configuration means clangDriver should no longer need to link with clangFrontEnd.

Fixes https://github.com/flang-compiler/flang/issues/779
    1. Move forward delcaration of class StringRef from under "opt" namespace to "llvm" namespace.
