### PR TITLE
Support for -gdwarf-5 option in Flang driver.

### DIFF
--- a/lib/Driver/ToolChains/Flang.cpp
+++ b/lib/Driver/ToolChains/Flang.cpp
@@ -318,6 +318,22 @@ void FlangFrontend::ConstructJob(Compilation &C, const JobAction &JA,
     CommonCmdArgs.push_back("0x4000");
   }
 
+  // -gdwarf-4
+  for (auto Arg : Args.filtered(options::OPT_gdwarf_4)) {
+    Arg->claim();
+    CommonCmdArgs.push_back("-x");
+    CommonCmdArgs.push_back("120");
+    CommonCmdArgs.push_back("0x1000000");
+  }
+
+  // -gdwarf-5
+  for (auto Arg : Args.filtered(options::OPT_gdwarf_5)) {
+    Arg->claim();
+    CommonCmdArgs.push_back("-x");
+    CommonCmdArgs.push_back("120");
+    CommonCmdArgs.push_back("0x2000000");
+  }
+
   // -Mipa has no effect
   if (Arg *A = Args.getLastArg(options::OPT_Mipa)) {
     getToolChain().getDriver().Diag(diag::warn_drv_clang_unsupported)


### PR DESCRIPTION
Summary:
  FLANG driver doesnt pass -gdwarf-4/5 to flang1 in form of xbits,
while it passes for -gdwarf-2/3
   -gdwarf-2 => -x 120 0x200
   -gdwarf-3 => -x 120 0x4000

Due to this -gdwarf-5 is never honored and default option -gdwarf-4
is taken.
    # flang -gdwarf-5 test.f90
    # llvm-dwarfdump a.out | grep version
    0x00000000: Compile Unit: length = 0x0000008e version = 0x0004

  Now 0x1000000/0x2000000 will be passed for -gdwarf-4/5
   -gdwarf-4 => -x 120 0x1000000
   -gdwarf-5 => -x 120 0x2000000

Testing:
  - GNU gdb fortran testsuite
  - check-llvm
  - check-debuginfo

Change-Id: I3d8fa0c4bd554787a6ac0fd3aca7d73ce7d9c9f1