### PR TITLE
Default dwarf version should be 4 for -g with flang

### DIFF
--- a/lib/Driver/ToolChains/Flang.cpp
+++ b/lib/Driver/ToolChains/Flang.cpp
@@ -312,7 +312,7 @@ void FlangFrontend::ConstructJob(Compilation &C, const JobAction &JA,
     CommonCmdArgs.push_back("-x");
     CommonCmdArgs.push_back("120");
 
-    if (!GDwarfArg) // -g should produce default (DWARFv4)
+    if (!GDwarfArg) // -g without -gdwarf-X produces default (DWARFv4)
       CommonCmdArgs.push_back("0x1000000");
     else if (GDwarfArg->getOption().matches(options::OPT_gdwarf_2)) // -gdwarf-2
       CommonCmdArgs.push_back("0x200");

--- a/lib/Driver/ToolChains/Flang.cpp
+++ b/lib/Driver/ToolChains/Flang.cpp
@@ -312,8 +312,8 @@ void FlangFrontend::ConstructJob(Compilation &C, const JobAction &JA,
     CommonCmdArgs.push_back("-x");
     CommonCmdArgs.push_back("120");
 
-    if (!GDwarfArg) // -g should produce default (DWARFv2)
-      CommonCmdArgs.push_back("0x200");
+    if (!GDwarfArg) // -g should produce default (DWARFv4)
+      CommonCmdArgs.push_back("0x1000000");
     else if (GDwarfArg->getOption().matches(options::OPT_gdwarf_2)) // -gdwarf-2
       CommonCmdArgs.push_back("0x200");
     else if (GDwarfArg->getOption().matches(options::OPT_gdwarf_3)) // -gdwarf-3

--- a/lib/Driver/ToolChains/Flang.cpp
+++ b/lib/Driver/ToolChains/Flang.cpp
@@ -318,6 +318,22 @@ void FlangFrontend::ConstructJob(Compilation &C, const JobAction &JA,
     CommonCmdArgs.push_back("0x4000");
   }
 
+  // -gdwarf-4
+  for (auto Arg : Args.filtered(options::OPT_gdwarf_4)) {
+    Arg->claim();
+    CommonCmdArgs.push_back("-x");
+    CommonCmdArgs.push_back("120");
+    CommonCmdArgs.push_back("0x1000000");
+  }
+
+  // -gdwarf-5
+  for (auto Arg : Args.filtered(options::OPT_gdwarf_5)) {
+    Arg->claim();
+    CommonCmdArgs.push_back("-x");
+    CommonCmdArgs.push_back("120");
+    CommonCmdArgs.push_back("0x2000000");
+  }
+
   // -Mipa has no effect
   if (Arg *A = Args.getLastArg(options::OPT_Mipa)) {
     getToolChain().getDriver().Diag(diag::warn_drv_clang_unsupported)

--- a/lib/Driver/ToolChains/Flang.cpp
+++ b/lib/Driver/ToolChains/Flang.cpp
@@ -294,44 +294,34 @@ void FlangFrontend::ConstructJob(Compilation &C, const JobAction &JA,
     CommonCmdArgs.push_back("8");
   }
 
-  // -g should produce DWARFv2
-  for (auto Arg : Args.filtered(options::OPT_g_Flag)) {
-    Arg->claim();
-    CommonCmdArgs.push_back("-x");
-    CommonCmdArgs.push_back("120");
-    CommonCmdArgs.push_back("0x200");
-  }
+  // Last argument of -g/-gdwarfX should be taken.
+  Arg *GArg = Args.getLastArg(options::OPT_g_Flag);
+  Arg *GDwarfArg = Args.getLastArg(options::OPT_gdwarf_2,
+                                   options::OPT_gdwarf_3,
+                                   options::OPT_gdwarf_4,
+                                   options::OPT_gdwarf_5);
 
-  // -gdwarf-2
-  for (auto Arg : Args.filtered(options::OPT_gdwarf_2)) {
-    Arg->claim();
-    CommonCmdArgs.push_back("-x");
-    CommonCmdArgs.push_back("120");
-    CommonCmdArgs.push_back("0x200");
-  }
+  if (GArg || GDwarfArg) {
 
-  // -gdwarf-3
-  for (auto Arg : Args.filtered(options::OPT_gdwarf_3)) {
-    Arg->claim();
-    CommonCmdArgs.push_back("-x");
-    CommonCmdArgs.push_back("120");
-    CommonCmdArgs.push_back("0x4000");
-  }
+    for (auto Arg : Args.filtered(options::OPT_g_Flag, options::OPT_gdwarf_2,
+                                  options::OPT_gdwarf_3, options::OPT_gdwarf_4,
+                                  options::OPT_gdwarf_5)) {
+      Arg->claim();
+    }
 
-  // -gdwarf-4
-  for (auto Arg : Args.filtered(options::OPT_gdwarf_4)) {
-    Arg->claim();
     CommonCmdArgs.push_back("-x");
     CommonCmdArgs.push_back("120");
-    CommonCmdArgs.push_back("0x1000000");
-  }
 
-  // -gdwarf-5
-  for (auto Arg : Args.filtered(options::OPT_gdwarf_5)) {
-    Arg->claim();
-    CommonCmdArgs.push_back("-x");
-    CommonCmdArgs.push_back("120");
-    CommonCmdArgs.push_back("0x2000000");
+    if (!GDwarfArg) // -g should produce default (DWARFv2)
+      CommonCmdArgs.push_back("0x200");
+    else if (GDwarfArg->getOption().matches(options::OPT_gdwarf_2)) // -gdwarf-2
+      CommonCmdArgs.push_back("0x200");
+    else if (GDwarfArg->getOption().matches(options::OPT_gdwarf_3)) // -gdwarf-3
+      CommonCmdArgs.push_back("0x4000");
+    else if (GDwarfArg->getOption().matches(options::OPT_gdwarf_4)) // -gdwarf-4
+      CommonCmdArgs.push_back("0x1000000");
+    else if (GDwarfArg->getOption().matches(options::OPT_gdwarf_5)) // -gdwarf-5
+      CommonCmdArgs.push_back("0x2000000");
   }
 
   // -Mipa has no effect


### PR DESCRIPTION
Currently flang dumps dwarf version 2 for -g and 4 for absence of -g

-------------------------
$ flang my.f90
$ llvm-dwarfdump a.out | grep version
0x00000000: Compile Unit: length = 0x0000003d version = 0x0004 abbr_offset = 0x0000 addr_size = 0x08 (next unit at 0x00000041)

$ flang -g my.f90
$ llvm-dwarfdump a.out | grep version
0x00000000: Compile Unit: length = 0x00000047 version = 0x0002 abbr_offset = 0x0000 addr_size = 0x08 (next unit at 0x0000004b)
-------------------------

It should be 4 for -g as it is the case with clang.

Please review commit 8afb75d on this branch other two reviews on this branch are already approved and ready to be merged.
