### PR TITLE
[DebugInfo] Support for DWARF 4/5 and fix of issues related to -gdwarf-X options

### DIFF
--- a/lib/Driver/ToolChains/Flang.cpp
+++ b/lib/Driver/ToolChains/Flang.cpp
@@ -352,6 +352,22 @@ void FlangFrontend::ConstructJob(Compilation &C, const JobAction &JA,
     CommonCmdArgs.push_back("0x4000");
   }
 
+  // -gdwarf-4
+  for (auto Arg : Args.filtered(options::OPT_gdwarf_4)) {
+    Arg->claim();
+    CommonCmdArgs.push_back("-x");
+    CommonCmdArgs.push_back("120");
+    CommonCmdArgs.push_back("0x1000000");
+  }
+
+  // -gdwarf-5
+  for (auto Arg : Args.filtered(options::OPT_gdwarf_5)) {
+    Arg->claim();
+    CommonCmdArgs.push_back("-x");
+    CommonCmdArgs.push_back("120");
+    CommonCmdArgs.push_back("0x2000000");
+  }
+
   // -Mipa has no effect
   if (Arg *A = Args.getLastArg(options::OPT_Mipa)) {
     getToolChain().getDriver().Diag(diag::warn_drv_clang_unsupported)

--- a/lib/Driver/ToolChains/Flang.cpp
+++ b/lib/Driver/ToolChains/Flang.cpp
@@ -328,44 +328,34 @@ void FlangFrontend::ConstructJob(Compilation &C, const JobAction &JA,
     LowerCmdArgs.push_back("0x8");
   }
 
-  // -g should produce DWARFv2
-  for (auto Arg : Args.filtered(options::OPT_g_Flag)) {
-    Arg->claim();
-    CommonCmdArgs.push_back("-x");
-    CommonCmdArgs.push_back("120");
-    CommonCmdArgs.push_back("0x200");
-  }
+  // Last argument of -g/-gdwarfX should be taken.
+  Arg *GArg = Args.getLastArg(options::OPT_g_Flag);
+  Arg *GDwarfArg = Args.getLastArg(options::OPT_gdwarf_2,
+                                   options::OPT_gdwarf_3,
+                                   options::OPT_gdwarf_4,
+                                   options::OPT_gdwarf_5);
 
-  // -gdwarf-2
-  for (auto Arg : Args.filtered(options::OPT_gdwarf_2)) {
-    Arg->claim();
-    CommonCmdArgs.push_back("-x");
-    CommonCmdArgs.push_back("120");
-    CommonCmdArgs.push_back("0x200");
-  }
+  if (GArg || GDwarfArg) {
 
-  // -gdwarf-3
-  for (auto Arg : Args.filtered(options::OPT_gdwarf_3)) {
-    Arg->claim();
-    CommonCmdArgs.push_back("-x");
-    CommonCmdArgs.push_back("120");
-    CommonCmdArgs.push_back("0x4000");
-  }
+    for (auto Arg : Args.filtered(options::OPT_g_Flag, options::OPT_gdwarf_2,
+                                  options::OPT_gdwarf_3, options::OPT_gdwarf_4,
+                                  options::OPT_gdwarf_5)) {
+      Arg->claim();
+    }
 
-  // -gdwarf-4
-  for (auto Arg : Args.filtered(options::OPT_gdwarf_4)) {
-    Arg->claim();
     CommonCmdArgs.push_back("-x");
     CommonCmdArgs.push_back("120");
-    CommonCmdArgs.push_back("0x1000000");
-  }
 
-  // -gdwarf-5
-  for (auto Arg : Args.filtered(options::OPT_gdwarf_5)) {
-    Arg->claim();
-    CommonCmdArgs.push_back("-x");
-    CommonCmdArgs.push_back("120");
-    CommonCmdArgs.push_back("0x2000000");
+    if (!GDwarfArg) // -g should produce default (DWARFv2)
+      CommonCmdArgs.push_back("0x200");
+    else if (GDwarfArg->getOption().matches(options::OPT_gdwarf_2)) // -gdwarf-2
+      CommonCmdArgs.push_back("0x200");
+    else if (GDwarfArg->getOption().matches(options::OPT_gdwarf_3)) // -gdwarf-3
+      CommonCmdArgs.push_back("0x4000");
+    else if (GDwarfArg->getOption().matches(options::OPT_gdwarf_4)) // -gdwarf-4
+      CommonCmdArgs.push_back("0x1000000");
+    else if (GDwarfArg->getOption().matches(options::OPT_gdwarf_5)) // -gdwarf-5
+      CommonCmdArgs.push_back("0x2000000");
   }
 
   // -Mipa has no effect

--- a/lib/Driver/ToolChains/Flang.cpp
+++ b/lib/Driver/ToolChains/Flang.cpp
@@ -346,8 +346,8 @@ void FlangFrontend::ConstructJob(Compilation &C, const JobAction &JA,
     CommonCmdArgs.push_back("-x");
     CommonCmdArgs.push_back("120");
 
-    if (!GDwarfArg) // -g should produce default (DWARFv2)
-      CommonCmdArgs.push_back("0x200");
+    if (!GDwarfArg) // -g without -gdwarf-X produces default (DWARFv4)
+      CommonCmdArgs.push_back("0x1000000");
     else if (GDwarfArg->getOption().matches(options::OPT_gdwarf_2)) // -gdwarf-2
       CommonCmdArgs.push_back("0x200");
     else if (GDwarfArg->getOption().matches(options::OPT_gdwarf_3)) // -gdwarf-3


### PR DESCRIPTION
Current pull request is merge of #89 #90 and #91 (all approved) on release_90 branch.

It has 3 commits to 
- Support DWARF version 4 and 5 in driver.
- Fix the issue when multiple -gdwarf-X options are present in command line.
- Setting 4 as default DWARF version when explicitly not mentioned with -gdwarf-N but -g is present.

Note: this patch would work with Flang patch https://github.com/flang-compiler/flang/pull/863