### PR TITLE
[DebugInfo] -gpubnames option support in Driver

### DIFF
--- a/lib/Driver/ToolChains/Flang.cpp
+++ b/lib/Driver/ToolChains/Flang.cpp
@@ -330,16 +330,16 @@ void FlangFrontend::ConstructJob(Compilation &C, const JobAction &JA,
 
   // Last argument of -g/-gdwarfX should be taken.
   Arg *GArg = Args.getLastArg(options::OPT_g_Flag);
-  Arg *GDwarfArg = Args.getLastArg(options::OPT_gdwarf_2,
-                                   options::OPT_gdwarf_3,
-                                   options::OPT_gdwarf_4,
-                                   options::OPT_gdwarf_5);
+  Arg *GDwarfArg = Args.getLastArg(options::OPT_gdwarf_2, options::OPT_gdwarf_3,
+                                   options::OPT_gdwarf_4, options::OPT_gdwarf_5,
+                                   options::OPT_gpubnames);
 
   if (GArg || GDwarfArg) {
 
-    for (auto Arg : Args.filtered(options::OPT_g_Flag, options::OPT_gdwarf_2,
-                                  options::OPT_gdwarf_3, options::OPT_gdwarf_4,
-                                  options::OPT_gdwarf_5)) {
+    for (auto Arg :
+         Args.filtered(options::OPT_g_Flag, options::OPT_gdwarf_2,
+                       options::OPT_gdwarf_3, options::OPT_gdwarf_4,
+                       options::OPT_gdwarf_5, options::OPT_gpubnames)) {
       Arg->claim();
     }
 
@@ -356,6 +356,9 @@ void FlangFrontend::ConstructJob(Compilation &C, const JobAction &JA,
       CommonCmdArgs.push_back("0x1000000");
     else if (GDwarfArg->getOption().matches(options::OPT_gdwarf_5)) // -gdwarf-5
       CommonCmdArgs.push_back("0x2000000");
+    else if (GDwarfArg->getOption().matches(
+                 options::OPT_gpubnames)) // -gpubnames
+      CommonCmdArgs.push_back("0x40000000");
   }
 
   // -Mipa has no effect


### PR DESCRIPTION
This option controls the production of .debug_names section (in DWARFv5)
and .debug_pubnames section (in DWARFv4).

Flang side support is provided in
https://github.com/flang-compiler/flang/pull/934